### PR TITLE
fix: bump node version

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -21,5 +21,5 @@ outputs:
   version:
     description: Exact version of Aiken that was installed
 runs:
-  using: node16
+  using: node20
   main: dist/index.js


### PR DESCRIPTION
It fixes this warning message.

```
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3, aiken-lang/setup-aiken@v0.1.0. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
```


> [GitHub Actions: Transitioning from Node 16 to Node 20](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/).  Our plan is to transition all actions to run on Node 20 by Spring 2024. 


@rvcas 